### PR TITLE
Fixed the testnet2 network start time. Removed legacy network.

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -23,17 +23,12 @@
   "networks": {
     "testnet2": {
       "genesis": "96fceff972c2c06bd3bb5243c39215333be6d56aaf4823073dca31afe5038471",
-      "startTime": 1563999636,
+      "startTime": 1563999616,
       "networkMagic": 1097911063
     },
     "staging": {
       "genesis": "c6a004d3d178f600cd8caa10abbebe1549bef878f0665aea2903472d5abf7323",
       "startTime": 1506450213
-    },
-    "testnet": {
-      "genesis": "b7f76950bc4866423538ab7764fc1c7020b24a5f717a5bee3109ff2796567214",
-      "startTime": 1537941600,
-      "networkMagic": 1097911063
     },
     "mainnet": {
       "genesis": "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb",


### PR DESCRIPTION
Database needs to be resynced after merging this, testnet time was by 1 slot off =(

Or
```
update txs set time = (time - interval '20 seconds');
```