### PR TITLE
Implemented storing `slot` objects for empty slots

### DIFF
--- a/src/blockchain/block.js
+++ b/src/blockchain/block.js
@@ -84,18 +84,19 @@ export default class Block {
     }
   }
 
-  static handleRegularBlock(header: HeaderType, body: {}, blockHash: string,
-    networkStartTime: number) {
+  static handleRegularBlock(
+    header: HeaderType,
+    body: {},
+    blockHash: string,
+    networkStartTime: number
+  ) {
     const consensus = header[3]
     const [epoch, slot] = consensus[0]
     const lead = consensus[1].toString('hex')
     const [chainDifficulty] = consensus[2]
     const txs = body[0]
     const [upd1, upd2] = body[3]
-    const blockTime = new Date(
-      (networkStartTime
-      + (epoch * SLOTS_IN_EPOCH + slot) * 20)
-      * 1000)
+    const blockTime = this.calcSlotTime(epoch, slot, networkStartTime)
 
     const res = {
       slot,
@@ -120,7 +121,7 @@ export default class Block {
   }
 
 
-  static parseBlock(blob: Buffer, handleRegularBlock: number): Block {
+  static parseBlock(blob: Buffer, networkStartTime: number): Block {
     const [type, [header, body]] = cbor.decode(blob)
     const hash = utils.headerToId(header, type)
     const common = {
@@ -137,7 +138,7 @@ export default class Block {
       case 1:
         blockData = {
           ...common,
-          ...Block.handleRegularBlock(header, body, hash, handleRegularBlock),
+          ...Block.handleRegularBlock(header, body, hash, networkStartTime),
         }
         break
       default:
@@ -146,8 +147,15 @@ export default class Block {
     return new Block(blockData)
   }
 
-  static fromCBOR(data: Buffer, handleRegularBlock: number) {
-    const block = Block.parseBlock(data, handleRegularBlock)
+  static fromCBOR(data: Buffer, networkStartTime: number) {
+    const block = Block.parseBlock(data, networkStartTime)
     return block
+  }
+
+  static calcSlotTime(epoch: number, slot: number, networkStartTime: number): Date {
+    const globalSlot = epoch * SLOTS_IN_EPOCH + slot
+    const secondsFromStart = globalSlot * 20
+    const slotUnitSeconds = networkStartTime + secondsFromStart
+    return new Date(slotUnitSeconds * 1000)
   }
 }

--- a/src/entities/elastic-storage/block-data.js
+++ b/src/entities/elastic-storage/block-data.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash'
 
-import type { Block } from '../../blockchain'
+import { Block } from '../../blockchain'
 
 import ElasticData, { coinFormat } from './elastic-data'
 import type { UtxoType } from './utxo-data'
@@ -46,6 +46,25 @@ class BlockData extends ElasticData {
         ...(new TxData(tx, this.allUtxos, txTrackedState, addressStates)).toPlainObject(),
       }))
     }
+  }
+
+  static emptySlot(
+    epoch: number,
+    slot: number,
+    networkStartTime: number,
+  ) {
+    return new BlockData(new Block({
+      hash: null,
+      slot: slot,
+      epoch: epoch,
+      height: null,
+      txs: [],
+      isEBB: false,
+      prevHash: null,
+      time: Block.calcSlotTime(epoch, slot, networkStartTime),
+      lead: null,
+      size: 0
+    }))
   }
 
   getReceivedAmount(): number {


### PR DESCRIPTION
In Elastic we want to track **`slots`** and not only `blocks`. So we need to detect **empty** slots and store special objects for them too.

For empty slots, we only track: epoch, slot, and time.