### PR TITLE
[Elastic] Inputs in `.txio` index

### DIFF
--- a/src/entities/elastic-storage/block-data.js
+++ b/src/entities/elastic-storage/block-data.js
@@ -20,6 +20,8 @@ class BlockData extends ElasticData {
 
   inputsData: [] = []
 
+  resolvedTxs: Array<TxData> = []
+
   txsData: Array<mixed> = []
 
   constructor(
@@ -41,10 +43,12 @@ class BlockData extends ElasticData {
       this.inputsData = _.flatMap(txs, 'inputs')
         .flatMap(inp => this.allUtxos[`${inp.txId}${inp.idx}`])
 
-      this.txsData = txs.map(tx => ({
+      this.resolvedTxs = txs.map(tx => new TxData(tx, this.allUtxos, txTrackedState, addressStates))
+
+      this.txsData = this.resolvedTxs.map(tx => ({
         epoch: block.epoch,
         slot: block.slot,
-        ...(new TxData(tx, this.allUtxos, txTrackedState, addressStates)).toPlainObject(),
+        ...tx.toPlainObject(),
       }))
     }
   }
@@ -67,6 +71,10 @@ class BlockData extends ElasticData {
       slotLeaderPk: null,
       size: 0
     }))
+  }
+
+  getResolvedTxs(): Array<TxData> {
+    return this.resolvedTxs
   }
 
   getReceivedAmount(): BigNumber {


### PR DESCRIPTION
1. Fixed elastic to store `inputs` in the `txio` index also
2. Also fixed `getGenesisLeaders` function from last PR
3. Also added sleep after deleting unsealed documents, cuz locally I were getting errors that indicate Elastic might still consider documents as present if queried right after the deleting is attempted (eventual consistency and all)