### PR TITLE
Full legacy address dump for the balance-check snapshot (Git LFS)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+migrations-shelley/data/known-legacy-addresses-byron-mainnet.txt filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Cardano chain data-importer (replacement for the `project-icarus-importer`)
 
 Tangata Manu is a tool to import Cardano blockchain data into an easily usable database storage (e.g. Postgres database). The main goal of the project is to provide the main middle-layer functionality and to allow easy connection for new custom data-storage connectors or data-provider connectors, basically allowing to read blockchain data from any source with an API (for example, different full-node implementations), and export it into any custom storage or database that you can connect.
 
+# We are using Git LFS!
+
+We are using external storage for large files, note that you need to have a special tool installed to have these files properly synced when cloning the repository.
+
+See: [https://git-lfs.github.com/](https://git-lfs.github.com/)
+
+Affected files:
+- [known-legacy-addresses-byron-mainnet.txt](migrations-shelley/data) (Postgres only)
+
+
 ## Pre-requisites
 
 * NodeJS v12.9.1. We recommend [nvm](https://github.com/creationix/nvm) to install it

--- a/migrations-shelley/1573472706108_add-known-legacy-addresses-table.js
+++ b/migrations-shelley/1573472706108_add-known-legacy-addresses-table.js
@@ -28,10 +28,18 @@ exports.up = async (pgm) => {
   })
 
   console.log('Inserting the known legacy addresses dump')
+  let lfsChecked = false
   let counter = 0
   for await (const line of rl) {
     // ignore comments or blank lines
     const strippedLine = line.trim()
+    if (!lfsChecked) {
+      if (strippedLine.startsWith('version https://git-lfs.github.com/spec')) {
+        throw Error(`The full legacy address dump file is located on Git LFS,
+        you need to download it manually or install a tool to sync it (see https://git-lfs.github.com)`)
+      }
+      lfsChecked = true
+    }
     if (strippedLine && !strippedLine.startsWith('#')) {
       const insertSql = Q.insert({
           replaceSingleQuotes: true

--- a/migrations-shelley/data/README.md
+++ b/migrations-shelley/data/README.md
@@ -1,0 +1,19 @@
+# Data files used in the DB schema migrations
+
+## known-legacy-addresses-byron-mainnet.txt
+
+### Git LFS
+
+Note that this file is too large to keep it in a regular GitHub repository, so we are using Git LFS.
+
+When you are checking out the repository - you need to manually download the file or install a special tool to properly sync it.
+
+See: [https://git-lfs.github.com/](https://git-lfs.github.com/) 
+
+### Purpose
+
+This file contains a dump of all distinct addresses ever used on the Cardano Byron mainnet before the Shelley snapshot.
+
+Shelley network is initialized with the full UTxO snapshot from the Byron network, so all the funds are transferred, but technically it is possible that for some wallet N first addresses were empty and then only address N+1 contained a UTxO, and N is greater than the [address gap limit according to the BIP44 standard](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#Address_gap_limit). In this case a BIP44 wallet would fail to recognise the UTxO.
+
+To solve this problem we are storing the set of all used legacy addresses, so the wallet can check if any of first 20 addresses were ever used, and see that next 20 must be generated. That way all the UTxOs must be properly detected by their wallets.

--- a/migrations-shelley/data/known-legacy-addresses-byron-mainnet.txt
+++ b/migrations-shelley/data/known-legacy-addresses-byron-mainnet.txt
@@ -1,4 +1,3 @@
-# Here we will put all the unique empty Byron legacy addresses seen before the Shelley snapshot
-# Empty lines or lines starting with '#' are ignored
-
-DdzFFzCqrht2WKNEFqHvMSumSQpcnMxcYLNNBXPYXyHpRk9M7PqVjZ5ysYzutnruNubzXak2NxT8UWTFQNzc77uzjQ1GtehBRBdAv7xb
+version https://git-lfs.github.com/spec/v1
+oid sha256:26b756f726585e563b65b769b873e71ac3ff96dfe4c976810d01b32e08a04ba9
+size 207817483


### PR DESCRIPTION
1. Full legacy address dump file is **uploaded to Git LFS** (https://git-lfs.github.com/)
2. Added safe-check to the migration code in case someone tries to run the migration with the LFS unsynced
3. Added readme to the directory with the large file
4. Added information about Git LFS to the main readme