### PR TITLE
Added `type: 'utxo'` when `inputs` are stored in txs as JSON objects

### DIFF
--- a/src/entities/postgres-storage/database.js
+++ b/src/entities/postgres-storage/database.js
@@ -243,6 +243,7 @@ class DB implements Database {
       id: row.utxo_id,
       index: row.tx_index,
       txHash: row.tx_hash,
+      type: 'utxo',
     }))
   }
 
@@ -491,6 +492,7 @@ class DB implements Database {
           amount: localUtxo.amount,
           txHash: localUtxo.tx_hash,
           index: localUtxo.tx_index,
+          type: 'utxo',
         })
         // Delete new Utxo if it's already spent in the same block
         delete newUtxos[utxoId]


### PR DESCRIPTION
Note, `type: 'utxo'` is appended in two places:
1. When we are storing the `inputs` column in `txs`, because a tx logically might at some point have different types of inputs
2. When we are **selecting** from the `utxos` table. Because there can't be anything other than UTxOs in the `utxos` table - it seemed excessive to store this information in each row, so it's just appended at query time.