### PR TITLE
Add Group address metadata to transaction

### DIFF
--- a/src/blockchain/shelley/utils.js
+++ b/src/blockchain/shelley/utils.js
@@ -81,8 +81,7 @@ const fragmentToObj = (fragment: any, extraData: {} = {}) => {
     }
     outputs_parsed.push({
       type: outputType,
-      // TODO: what bech prefix do we put here?
-      address: output.address().to_string('tc'),
+      address: Buffer.from(output.address().as_bytes()).toString('hex'),
       // See comment for input values
       value: parseInt(output.value().to_str(), 10),
     })

--- a/src/blockchain/shelley/utils.js
+++ b/src/blockchain/shelley/utils.js
@@ -42,11 +42,12 @@ const fragmentToObj = (fragment: any, extraData: {} = {}) => {
     const input = inputs.get(input_index)
     console.log(`tx input type: ${input.get_type()}`)
     if (input.is_utxo()) {
-      /*
       const utxo = input.get_utxo_pointer()
-      const txId = Buffer.from(utxo.fragment_id().as_bytes()).toString('hex')
-      inputs_parsed.push(TxInputType.fromUtxo(txId, utxo.output_index()))
-      */
+      inputs_parsed.push({
+        type: 'utxo',
+        txId: Buffer.from(utxo.fragment_id().as_bytes()).toString('hex'),
+        idx: utxo.output_index(),
+      })
     } else {
       const account = input.get_account_identifier()
       // TODO: Values are returned as strings under the rationale that js strings

--- a/src/entities/postgres-storage/database.js
+++ b/src/entities/postgres-storage/database.js
@@ -372,17 +372,21 @@ class DB implements Database {
       {
         const spendingKey = groupAddress.get_spending_key()
         const accountKey = groupAddress.get_account_key()
-        // TODO full address objects including discrim tomorrow
+        const discrim = address.get_discrimination()
+        const singleAddress = wasm.Address.single_from_public_key(spendingKey, discrim)
+        const accountAddress = wasm.Address.account_from_public_key(spendingKey, discrim)
         const metadata = {
           groupAddress: addressString,
-          utxoAddress: Buffer.from(spendingKey.as_bytes()).toString('hex'),
-          accountAddress: Buffer.from(accountKey.as_bytes()).toString('hex'),
+          utxoAddress: Buffer.from(singleAddress.as_bytes()).toString('hex'),
+          accountAddress: Buffer.from(accountAddress.as_bytes()).toString('hex'),
         }
+        singleAddress.free()
+        accountAddress.free()
         spendingKey.free()
         accountKey.free()
         groupAddress.free()
-        throw new Error(`finally found group address: ${JSON.stringify(metadata)}`)
-        //return metadata
+        //throw new Error(`finally found group address: ${JSON.stringify(metadata)}`)
+        return metadata
       }
       else
       {

--- a/src/entities/postgres-storage/db-shelley.js
+++ b/src/entities/postgres-storage/db-shelley.js
@@ -74,7 +74,7 @@ class DBShelley extends DB {
           const accountKey = groupAddress.get_account_key()
           const discrim = address.get_discrimination()
           const singleAddress = wasm.Address.single_from_public_key(spendingKey, discrim)
-          const accountAddress = wasm.Address.account_from_public_key(spendingKey, discrim)
+          const accountAddress = wasm.Address.account_from_public_key(accountKey, discrim)
           const metadata = {
             groupAddress: addressString,
             utxoAddress: Buffer.from(singleAddress.as_bytes()).toString('hex'),

--- a/src/entities/postgres-storage/db-shelley.js
+++ b/src/entities/postgres-storage/db-shelley.js
@@ -1,12 +1,14 @@
 // @flow
 
 import { helpers } from 'inversify-vanillajs-helpers'
+import _ from 'lodash'
 
 import SERVICE_IDENTIFIER from '../../constants/identifiers'
 import { CERT_TYPE } from '../../blockchain/shelley/certificate'
 import type { ShelleyTxType } from '../../blockchain/shelley/tx'
 
 import DB from './database'
+import type TxDbDataType from './database'
 import Q from './db-queries'
 
 
@@ -45,7 +47,53 @@ class DBShelley extends DB {
   async storeTx(tx: ShelleyTxType,
     txUtxos:Array<mixed> = [], upsert: boolean = true): Promise<void> {
     const { certificate } = tx
-    await super.storeTx(tx, txUtxos, upsert)
+    await super.storeTxImpl(tx, txUtxos, upsert, (txDbData: TxDbDataType): object => {
+      const wasm = global.jschainlibs
+      const {
+        inputAddresses, outputAddresses,
+      } = txDbData
+      const allAddresses = _.uniq([...inputAddresses, ...outputAddresses])
+      console.log(`metadataCreator.allAddresses = ${allAddresses}`)
+      return allAddresses.map(addressString => {
+        let address
+        try {
+          address = wasm.Address.from_bytes(Buffer.from(addressString, 'hex'))
+        } catch (e) {
+          const prefix = addressString.substring(0, 3)
+          // TODO: find a better way to distinguish legacy funds?
+          if (prefix != 'Ddz' && prefix != 'Ae2') {
+            throw new Error(`Group Metadata could not parse address: ${addressString}`)
+          }
+          return null
+        }
+        const groupAddress = address.to_group_address()
+        address.free()
+        if (groupAddress)
+        {
+          const spendingKey = groupAddress.get_spending_key()
+          const accountKey = groupAddress.get_account_key()
+          const discrim = address.get_discrimination()
+          const singleAddress = wasm.Address.single_from_public_key(spendingKey, discrim)
+          const accountAddress = wasm.Address.account_from_public_key(spendingKey, discrim)
+          const metadata = {
+            groupAddress: addressString,
+            utxoAddress: Buffer.from(singleAddress.as_bytes()).toString('hex'),
+            accountAddress: Buffer.from(accountAddress.as_bytes()).toString('hex'),
+          }
+          singleAddress.free()
+          accountAddress.free()
+          spendingKey.free()
+          accountKey.free()
+          groupAddress.free()
+          //throw new Error(`finally found group address: ${JSON.stringify(metadata)}`)
+          return metadata
+        }
+        else
+        {
+          return null;
+        }
+      }).filter(Boolean)
+    })
     if (certificate
       && (certificate.type === CERT_TYPE.StakeDelegation)) {
       await this.storeStakeDelegationCertTx(tx)


### PR DESCRIPTION
For each group address, tag the transaction with metadata breaking it into the respective single address and account (delegation) address;