### PR TITLE
Store raw certificate payload in txs

### DIFF
--- a/src/blockchain/shelley/certificate.js
+++ b/src/blockchain/shelley/certificate.js
@@ -11,8 +11,11 @@ export const CERT_TYPE = {
 }
 
 type CertificateCommonType = {
-  // hex-encoded raw binary payload of the certificate
-  payload: string,
+  payload: {
+    payloadKind: string,
+    // hex-encoded raw binary payload of the certificate
+    payloadHex: string,
+  },
 }
 
 export type PoolRegistrationType = {

--- a/src/blockchain/shelley/utils.js
+++ b/src/blockchain/shelley/utils.js
@@ -107,7 +107,10 @@ const fragmentToObj = (fragment: any, networkDiscrimination: number, extraData: 
           pool_owners.push(keyBytes.toString('hex'))
         }
         const parsedCert: PoolRegistrationType = {
-          payload,
+          payload: {
+            payloadKind: 'PoolRegistration',
+            payloadHex: payload,
+          },
           type: CERT_TYPE.PoolRegistration,
           pool_id: reg.id().to_string(),
           // we should be able to do this considering js max int would be 285,616,414 years
@@ -121,7 +124,10 @@ const fragmentToObj = (fragment: any, networkDiscrimination: number, extraData: 
         const deleg = cert.get_stake_delegation()
         const poolId = deleg.delegation_type().get_full()
         const parsedCert: StakeDelegationType = {
-          payload,
+          payload: {
+            payloadKind: 'StakeDelegation',
+            payloadHex: payload,
+          },
           type: CERT_TYPE.StakeDelegation,
           // TODO: handle DelegationType parsing
           pool_id: poolId != null ? poolId.to_string() : null,
@@ -134,7 +140,10 @@ const fragmentToObj = (fragment: any, networkDiscrimination: number, extraData: 
       case wasm.CertificateKind.PoolRetirement: {
         const retire = cert.get_pool_retirement()
         const parsedCert: PoolRetirementType = {
-          payload,
+          payload: {
+            payloadKind: 'PoolRetirement',
+            payloadHex: payload,
+          },
           type: CERT_TYPE.PoolRetirement,
           pool_id: retire.pool_id().to_string(),
           // we should be able to do this considering js max int would be 28,5616,414 years
@@ -153,7 +162,10 @@ const fragmentToObj = (fragment: any, networkDiscrimination: number, extraData: 
         const deleg = cert.get_owner_stake_delegation()
         const poolId = deleg.delegation_type().get_full()
         const parsedCert: StakeDelegationType = {
-          payload,
+          payload: {
+            payloadKind: 'OwnerStakeDelegation',
+            payloadHex: payload,
+          },
           type: CERT_TYPE.StakeDelegation,
           // TODO: possibly handle Ratio types
           pool_id: poolId != null ? poolId.to_string() : null,

--- a/src/entities/postgres-storage/database.js
+++ b/src/entities/postgres-storage/database.js
@@ -390,7 +390,8 @@ class DB<TxType: ByronTxType | ShelleyTxType> {
       })
     }
     const conn = this.getConn()
-    const sql = Q.TX_INSERT.setFields(txDbFields)
+    const sql = Q.newTxInsert()
+      .setFields(txDbFields)
       .onConflict(...onConflictArgs)
       .toString()
     this.logger.debug('Insert TX:', sql, inputAddresses)

--- a/src/entities/postgres-storage/db-queries.js
+++ b/src/entities/postgres-storage/db-queries.js
@@ -20,7 +20,7 @@ const BEST_BLOCK_UPDATE = sql.update().table('bestblock')
 
 const BLOCK_INSERT = sql.insert().into('blocks')
 
-const TX_INSERT = sql.insert().registerValueHandler(Array, psqlArrayValueHandler).into('txs')
+const newTxInsert = () => sql.insert().registerValueHandler(Array, psqlArrayValueHandler).into('txs')
 
 const TX_ADDRESSES_INSERT = sql.insert().into('tx_addresses').onConflict()
 
@@ -42,7 +42,7 @@ export default {
   GET_BEST_BLOCK_NUM,
   BEST_BLOCK_UPDATE,
   BLOCK_INSERT,
-  TX_INSERT,
+  newTxInsert,
   TX_ADDRESSES_INSERT,
   GET_UTXOS_BLOCKS_COUNT,
 }

--- a/src/entities/postgres-storage/db-queries.js
+++ b/src/entities/postgres-storage/db-queries.js
@@ -14,15 +14,15 @@ const psqlArrayValueHandler = (array) => {
   return `ARRAY[${data}]`
 }
 
-const UTXOS_INSERT = sql.insert().into('utxos')
+const newUtxosInsert = () => sql.insert().into('utxos')
 
-const BEST_BLOCK_UPDATE = sql.update().table('bestblock')
+const newBestBlockUpdate = () => sql.update().table('bestblock')
 
-const BLOCK_INSERT = sql.insert().into('blocks')
+const newBlockInsert = () => sql.insert().into('blocks')
 
 const newTxInsert = () => sql.insert().registerValueHandler(Array, psqlArrayValueHandler).into('txs')
 
-const TX_ADDRESSES_INSERT = sql.insert().into('tx_addresses').onConflict()
+const newTxAddressesInsert = () => sql.insert().into('tx_addresses').onConflict()
 
 const GET_BEST_BLOCK_NUM = sql.select()
   .from('blocks')
@@ -32,17 +32,19 @@ const GET_BEST_BLOCK_NUM = sql.select()
   .field('slot')
   .order('block_height', false)
   .limit(1)
+  .toString()
 
 const GET_UTXOS_BLOCKS_COUNT = sql.select()
   .field('(select count(*) from utxos ) + ( select count(*) from blocks) as cnt')
+  .toString()
 
 export default {
   sql,
-  UTXOS_INSERT,
+  newUtxosInsert,
   GET_BEST_BLOCK_NUM,
-  BEST_BLOCK_UPDATE,
-  BLOCK_INSERT,
+  newBestBlockUpdate,
+  newBlockInsert,
   newTxInsert,
-  TX_ADDRESSES_INSERT,
+  newTxAddressesInsert,
   GET_UTXOS_BLOCKS_COUNT,
 }

--- a/src/entities/postgres-storage/db-shelley.js
+++ b/src/entities/postgres-storage/db-shelley.js
@@ -239,9 +239,23 @@ class DBShelley extends DB<TxType> implements Database<TxType> {
     return { inputAddresses, inputAmounts, inputs }
   }
 
+  async getTxDBData(tx: TxType, txUtxos: Array<mixed> = []): Promise<TxDbDataType> {
+    let { txDbFields, inputAddresses, outputAddresses } = await super.getTxDBData(tx, txUtxos)
+    const { certificate } = tx
+    if (certificate && certificate.payload) {
+      txDbFields = {
+        ...txDbFields,
+        certificates: [
+          JSON.stringify(certificate.payload)
+        ]
+      }
+    }
+    return { txDbFields, inputAddresses, outputAddresses }
+  }
+
   async storeTx(tx: TxType,
     txUtxos:Array<mixed> = [], upsert: boolean = true): Promise<void> {
-    const { certificate } = tx
+    const { certificate, id } = tx
     const txDbData = await this.getTxDBData(tx, txUtxos)
     await super.storeTxImpl(tx, txUtxos, upsert, txDbData)
     await this.storeAccountsChanges(tx)


### PR DESCRIPTION
1. Changed the certificate payload struct type in the Jormun parser a bit  (to include cert kind)
2. Made db-shelley add cert payloads to txs when storing them in DB
3. As a bonus replaced SQUEL query constants with factory functions, cuz it turned out they are mutable and might cause hard-to-debug problems.

P.S. We need to additionally store `payloadKind` in cert payload instead of just using parsed field `certificate.type` because our parses can output the same parsed cert type for multiple Rust kinds (e.g. owner-delegation parsed into regular stake-delegation), while raw payload **MUST** be tagged with the original kind precisely.