### PR TITLE
Account state endpoint

### DIFF
--- a/src/api/account-info.js
+++ b/src/api/account-info.js
@@ -1,0 +1,85 @@
+// @flow
+
+import { zip as zipArrays, chain as lodashChain } from 'lodash'
+
+import type { Logger } from 'bunyan'
+
+import { Request, Response } from 'restify'
+import { Controller, Post } from 'inversify-restify-utils'
+import { Controller as IController } from 'inversify-restify-utils/lib/interfaces'
+import { decorate } from 'inversify'
+import { helpers } from 'inversify-vanillajs-helpers'
+
+import { JormungandrApi } from '../entities/raw-data-providers'
+import { shelleyUtils } from '../blockchain/shelley'
+
+import SERVICE_IDENTIFIER from '../constants/identifiers'
+
+class AccountInfoController implements IController {
+  logger: Logger
+
+  dataProvider: JormungandrApi
+
+  constructor(
+    logger: Logger,
+    dataProvider: JormungandrApi,
+  ) {
+    this.logger = logger
+    this.dataProvider = dataProvider
+  }
+
+  async accountInfo(req: Request, resp: Response, next: Function) {
+    const doResp = (status, statusText, respBody) => {
+      resp.status(status)
+      // eslint-disable-next-line no-param-reassign
+      resp.statusText = statusText
+      resp.send(respBody)
+      next()
+    }
+    let statusText
+    let status
+    let respBody
+    const addresses = req.body.addresses
+    if (!Array.isArray(addresses) || addresses.length > 50) {
+      return doResp(400, 'BadParam',
+        '`addresses` should be a valid array of no more than 50 account addresses')
+    }
+    this.logger.debug('Account info for addresses:', JSON.stringify(addresses))
+    const promises = addresses.map(addr => {
+      const { accountId, type, comment } = shelleyUtils.getAccountIdFromAddress(addr)
+      if (accountId) {
+        // returning promise here to make queries parallel
+        return this.dataProvider.getAccountState(accountId)
+      } else {
+        this.logger.debug('Failed to query account state for address:', JSON.stringify({ addr, type, comment }))
+        return {
+          error: 'address is not a correct supported account',
+          comment,
+        }
+      }
+    })
+    const resolved = await Promise.all(promises)
+    this.logger.debug('Resolved account state promises: ', addresses, resolved)
+    status = 200
+    statusText = '@ok'
+    respBody = lodashChain(zipArrays(addresses, resolved))
+      .keyBy(0)
+      .mapValues(1)
+      .value()
+    resp.status(status)
+    // eslint-disable-next-line no-param-reassign
+    resp.statusText = statusText
+    resp.send(respBody)
+    next()
+  }
+}
+
+helpers.annotate(AccountInfoController, [
+  SERVICE_IDENTIFIER.LOGGER,
+  SERVICE_IDENTIFIER.RAW_DATA_PROVIDER,
+])
+
+decorate(Controller('/api'), AccountInfoController)
+decorate(Post('/account/state'), AccountInfoController.prototype, 'accountInfo')
+
+export default AccountInfoController

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,3 +1,4 @@
 // @flow
 
-export { default } from './txs'
+export { default as TxController } from './txs'
+export { default as AccountInfoController } from './account-info'

--- a/src/blockchain/shelley/utils.js
+++ b/src/blockchain/shelley/utils.js
@@ -1,8 +1,9 @@
 // @flow
 
+import type { PoolRegistrationType, PoolRetirementType, StakeDelegationType } from './certificate'
 import { CERT_TYPE } from './certificate'
-import type { StakeDelegationType, PoolRegistrationType, PoolRetirementType } from './certificate'
 import type { ShelleyTxType } from './tx'
+import { AddressKind } from '../../../js-chain-libs/pkg/js_chain_libs';
 
 const fragmentToObj = (fragment: any, networkDiscrimination: number, extraData: {txTime: Date}): ShelleyTxType => {
   const wasm = global.jschainlibs
@@ -196,6 +197,62 @@ const fragmentToObj = (fragment: any, networkDiscrimination: number, extraData: 
   return ret
 }
 
+const splitGroupAddress = (groupAddressHex: string) => {
+  const wasm = global.jschainlibs
+  let address
+  try {
+    address = wasm.Address.from_bytes(Buffer.from(groupAddressHex, 'hex'))
+  } catch (e) {
+    const prefix = groupAddressHex.substring(0, 3)
+    // TODO: find a better way to distinguish legacy funds?
+    if (prefix !== 'Ddz' && prefix !== 'Ae2') {
+      throw new Error(`Group Metadata could not parse address: ${groupAddressHex}`)
+    }
+    return null
+  }
+  let result = null
+  const kind = address.get_kind()
+  if (kind === AddressKind.Group) {
+    const groupAddress = address.to_group_address()
+    if (groupAddress) {
+      const spendingKey = groupAddress.get_spending_key()
+      const accountKey = groupAddress.get_account_key()
+      const discrim = address.get_discrimination()
+      const singleAddress = wasm.Address.single_from_public_key(spendingKey, discrim)
+      const accountAddress = wasm.Address.account_from_public_key(accountKey, discrim)
+      const metadata = {
+        type: 'group',
+        groupAddress: groupAddressHex,
+        utxoAddress: Buffer.from(singleAddress.as_bytes()).toString('hex'),
+        accountAddress: Buffer.from(accountAddress.as_bytes()).toString('hex'),
+      }
+      singleAddress.free()
+      accountAddress.free()
+      spendingKey.free()
+      accountKey.free()
+      groupAddress.free()
+      result = metadata
+    }
+  } else if (kind === AddressKind.Single) {
+    result = {
+      type: 'utxo',
+      utxoAddress: Buffer.from(address.as_bytes()).toString('hex'),
+    }
+  } else if (kind === AddressKind.Account) {
+    result = {
+      type: 'account',
+      accountAddress: Buffer.from(address.as_bytes()).toString('hex'),
+    }
+  } else {
+    // Unsupported type
+    result = {
+      type: 'unknown',
+    }
+  }
+  address.free()
+  return result
+}
+
 const rawTxToObj = (tx: Array<any>, networkDiscrimination: number, extraData: {txTime: Date}): ShelleyTxType => {
   const wasm = global.jschainlibs
   return fragmentToObj(wasm.Fragment.from_bytes(tx), networkDiscrimination, extraData)
@@ -204,4 +261,5 @@ const rawTxToObj = (tx: Array<any>, networkDiscrimination: number, extraData: {t
 export default {
   rawTxToObj,
   fragmentToObj,
+  splitGroupAddress,
 }

--- a/src/entities/postgres-storage/db-shelley.js
+++ b/src/entities/postgres-storage/db-shelley.js
@@ -2,6 +2,7 @@
 
 import _ from 'lodash'
 
+import { shelleyUtils } from '../../blockchain/shelley'
 import { CERT_TYPE } from '../../blockchain/shelley/certificate'
 import type {
   ShelleyTxType as TxType,
@@ -183,47 +184,10 @@ class DBShelley extends DB<TxType> implements Database<TxType> {
   }
 
   getGroupAddressesData(txDbData: TxDbDataType) {
-    const wasm = global.jschainlibs
-    const {
-      inputAddresses, outputAddresses,
-    } = txDbData
+    const { inputAddresses, outputAddresses } = txDbData
     const allAddresses = _.uniq([...inputAddresses, ...outputAddresses])
     this.logger.debug(`metadataCreator.allAddresses = ${allAddresses}`)
-    return allAddresses.map(addressString => {
-      let address
-      try {
-        address = wasm.Address.from_bytes(Buffer.from(addressString, 'hex'))
-      } catch (e) {
-        const prefix = addressString.substring(0, 3)
-        // TODO: find a better way to distinguish legacy funds?
-        if (prefix !== 'Ddz' && prefix !== 'Ae2') {
-          throw new Error(`Group Metadata could not parse address: ${addressString}`)
-        }
-        return null
-      }
-      const groupAddress = address.to_group_address()
-      let result = null
-      if (groupAddress) {
-        const spendingKey = groupAddress.get_spending_key()
-        const accountKey = groupAddress.get_account_key()
-        const discrim = address.get_discrimination()
-        const singleAddress = wasm.Address.single_from_public_key(spendingKey, discrim)
-        const accountAddress = wasm.Address.account_from_public_key(accountKey, discrim)
-        const metadata = {
-          groupAddress: addressString,
-          utxoAddress: Buffer.from(singleAddress.as_bytes()).toString('hex'),
-          accountAddress: Buffer.from(accountAddress.as_bytes()).toString('hex'),
-        }
-        singleAddress.free()
-        accountAddress.free()
-        spendingKey.free()
-        accountKey.free()
-        groupAddress.free()
-        result = metadata
-      }
-      address.free()
-      return result
-    }).filter(Boolean)
+    return allAddresses.map(shelleyUtils.splitGroupAddress).filter(x => x.groupAddress)
   }
 
   async getTxInputsDbData(tx: TxType, txUtxos: Array<mixed> = []): Promise<TxInputsDbDataType> {

--- a/src/entities/raw-data-providers/jormungandr-api.js
+++ b/src/entities/raw-data-providers/jormungandr-api.js
@@ -87,6 +87,11 @@ class JormungandrApi implements RawDataProvider {
     return resp
   }
 
+  async getAccountState(accountId: string): Promise<any> {
+    const resp = await this.getJson(`account/${accountId}`)
+    return resp.data
+  }
+
   // payload is base64 encoded raw binary signed transaction
   async postSignedTx(payload: string): Promise<any> {
     // Jormungandr expects a binary POST input

--- a/src/ioc_config/routes.js
+++ b/src/ioc_config/routes.js
@@ -4,10 +4,21 @@ import { Container } from 'inversify'
 import { TYPE } from 'inversify-restify-utils'
 import { Controller as IController } from 'inversify-restify-utils/lib/interfaces'
 
-import TxController from '../api'
+import { TxController, AccountInfoController } from '../api'
+import type { NetworkConfig } from '../interfaces';
+import { NETWORK_PROTOCOL } from "../entities/network-config"
+import SERVICE_IDENTIFIER from '../constants/identifiers';
 
 const initRoutes = (container: Container) => {
+
+  const networkConfig = container.get<NetworkConfig>(SERVICE_IDENTIFIER.NETWORK_CONFIG)
+  const networkProtocol = networkConfig.networkProtocol()
+
   container.bind<IController>(TYPE.Controller).to(TxController).whenTargetNamed('TxController')
+
+  if (networkProtocol === NETWORK_PROTOCOL.SHELLEY) {
+    container.bind<IController>(TYPE.Controller).to(AccountInfoController).whenTargetNamed('AccountInfoController')
+  }
 }
 
 export default initRoutes


### PR DESCRIPTION
1. Introduced a new endpoint to query the current state for multiple accounts at once. Proxies to the Jormun endpoint for now.
2. Refactored db-shelley a bit to move the wasm-specific code into parser utils