### PR TITLE
Sent txs to transient snapshot

### DIFF
--- a/src/entities/cron.js
+++ b/src/entities/cron.js
@@ -83,15 +83,15 @@ class CronScheduler implements Scheduler {
     if (consecutiveRollbackCounter >= 0) {
       if (consecutiveRollbackCounter === 0) {
         // Drop 1 last block for the first rollback attempt, that's 99% of cases
-        return 1
+        return Math.min(1, this.rollbackBlocksCount)
       }
       if (consecutiveRollbackCounter === 1) {
         // Drop 2 last blocks as an extra measure, should cover another 0.999% of cases
-        return 2
+        return Math.min(2, this.rollbackBlocksCount)
       }
       if (consecutiveRollbackCounter > 1 && consecutiveRollbackCounter < 5) {
         // Try dropping 5 blocks for next multiple times, if this doesn't help the rollback is critical
-        return 5
+        return Math.min(5, this.rollbackBlocksCount)
       }
     }
     return this.rollbackBlocksCount

--- a/src/entities/cron.js
+++ b/src/entities/cron.js
@@ -52,6 +52,8 @@ class CronScheduler implements Scheduler {
 
   networkProtocol: string
 
+  consecutiveRollbackCounter: number = 0
+
   constructor(
     dataProvider: RawDataProvider,
     checkTipSeconds: number,
@@ -67,7 +69,7 @@ class CronScheduler implements Scheduler {
     this.checkTipMillis = checkTipSeconds * 1000
     this.maxBlockBatchSize = maxBlockBatchSize
     logger.debug('Checking tip every', checkTipSeconds, 'seconds')
-    logger.debug('Rollback blocks count', rollbackBlocksCount)
+    logger.debug('Max rollback blocks count', rollbackBlocksCount)
     this.logger = logger
     this.blocksToStore = []
     this.lastBlock = null
@@ -77,15 +79,34 @@ class CronScheduler implements Scheduler {
     logger.debug(`genesisHash = ${this.#genesisHash}`)
   }
 
-  async rollback(atBlockHeight: number) {
-    this.logger.info(`Rollback at height ${atBlockHeight} to ${this.rollbackBlocksCount} blocks back.`)
+  calculateRollbackDepth(consecutiveRollbackCounter: number): number {
+    if (consecutiveRollbackCounter >= 0) {
+      if (consecutiveRollbackCounter === 0) {
+        // Drop 1 last block for the first rollback attempt, that's 99% of cases
+        return 1
+      }
+      if (consecutiveRollbackCounter === 1) {
+        // Drop 2 last blocks as an extra measure, should cover another 0.999% of cases
+        return 2
+      }
+      if (consecutiveRollbackCounter > 1 && consecutiveRollbackCounter < 5) {
+        // Try dropping 5 blocks for next multiple times, if this doesn't help the rollback is critical
+        return 5
+      }
+    }
+    return this.rollbackBlocksCount
+  }
+
+  async rollback(atBlockHeight: number, consecutiveRollbackCounter: number = -1) {
+    const rollbackDepth = this.calculateRollbackDepth(consecutiveRollbackCounter)
+    this.logger.info(`Rollback at height ${atBlockHeight} to ${rollbackDepth} blocks back.`)
     // reset scheduler state
     this.blocksToStore = []
     this.lastBlock = null
 
     // Recover database state to newest actual block.
     const { height } = await this.storageProcessor.getBestBlockNum()
-    const rollBackTo = height - this.rollbackBlocksCount
+    const rollBackTo = height - rollbackDepth
     this.logger.info(`Current DB height at rollback time: ${height}. Rolling back to: ${rollBackTo}`)
     await this.storageProcessor.rollbackTo(rollBackTo)
     const { epoch, hash } = await this.storageProcessor.getBestBlockNum()
@@ -230,8 +251,12 @@ class CronScheduler implements Scheduler {
 
       if (status === STATUS_ROLLBACK_REQUIRED) {
         this.logger.info('Rollback required.')
-        await this.rollback(blockHeight)
+        await this.rollback(blockHeight, this.consecutiveRollbackCounter)
+        // Increment the counter in case next attempt will also cause a rollback
+        this.consecutiveRollbackCounter += 1
         return
+      } else {
+        this.consecutiveRollbackCounter = 0
       }
     }
   }

--- a/src/entities/postgres-storage/database.js
+++ b/src/entities/postgres-storage/database.js
@@ -530,6 +530,7 @@ class DB<TxType: ByronTxType | ShelleyTxType> {
     const sql = Q.sql.insert()
       .into(SNAPSHOTS_TABLE)
       .setFieldsRows(dbFields)
+      .onConflict()
       .toString()
     this.logger.debug('storeNewPendingSnapshot: ', sql)
     await this.getConn().query(sql)

--- a/src/entities/postgres-storage/database.js
+++ b/src/entities/postgres-storage/database.js
@@ -520,7 +520,7 @@ class DB<TxType: ByronTxType | ShelleyTxType> {
       throw new Error(`[addNewTxToPendingSnapshot] Incorrect tx status: ${txStatus}! 
        Expected one of: '${TX_STATUS.TX_PENDING_STATUS}' or '${TX_STATUS.TX_FAILED_STATUS}'`)
     }
-    const { hash, height } = this.getBestBlockNum()
+    const { hash, height } = await this.getBestBlockNum()
     const dbFields = [{
       tx_hash: txHash,
       block_hash: hash,

--- a/src/entities/postgres-storage/database.js
+++ b/src/entities/postgres-storage/database.js
@@ -511,13 +511,13 @@ class DB<TxType: ByronTxType | ShelleyTxType> {
   }
 
   async addNewTxToTransientSnapshots(txHash: string, txStatus: string) {
-    this.logger.debug('addNewTxToPendingSnapshot:', txHash, txStatus)
+    this.logger.debug('addNewTxToTransientSnapshots:', txHash, txStatus)
     if (!txHash) {
-      this.logger.debug('addNewTxToPendingSnapshot: No tx is provided')
+      this.logger.debug('addNewTxToTransientSnapshots: No tx is provided')
       return
     }
     if (txStatus !== TX_STATUS.TX_PENDING_STATUS && txStatus !== TX_STATUS.TX_FAILED_STATUS) {
-      throw new Error(`[addNewTxToPendingSnapshot] Incorrect tx status: ${txStatus}! 
+      throw new Error(`[addNewTxToTransientSnapshots] Incorrect tx status: ${txStatus}! 
        Expected one of: '${TX_STATUS.TX_PENDING_STATUS}' or '${TX_STATUS.TX_FAILED_STATUS}'`)
     }
     const { hash, height } = await this.getBestBlockNum()
@@ -532,7 +532,7 @@ class DB<TxType: ByronTxType | ShelleyTxType> {
       .setFieldsRows(dbFields)
       .onConflict()
       .toString()
-    this.logger.debug('storeNewPendingSnapshot: ', sql)
+    this.logger.debug('addNewTxToTransientSnapshots: ', sql)
     await this.getConn().query(sql)
   }
 

--- a/src/entities/postgres-storage/postgres-storage-processor.js
+++ b/src/entities/postgres-storage/postgres-storage-processor.js
@@ -23,7 +23,7 @@ class PostgresStorageProcessor implements StorageProcessor {
   }
 
   async storeBlocksData(blocks: Array<Block>) {
-    return this.doInTransaction(async () => {
+    return this.db.doInTransaction(async () => {
       await this.db.storeBlocks(blocks)
       for (const block of blocks) {
         const blockHaveTxs = !_.isEmpty(block.getTxs())
@@ -37,21 +37,9 @@ class PostgresStorageProcessor implements StorageProcessor {
   }
 
   async rollbackTo(height: number) {
-    return this.doInTransaction(async () => {
+    return this.db.doInTransaction(async () => {
       await this.db.rollbackTo(height)
     })
-  }
-
-  async doInTransaction(callback) {
-    const dbConn = this.db.getConn()
-    try {
-      await dbConn.query('BEGIN')
-      await callback()
-      await dbConn.query('COMMIT')
-    } catch (e) {
-      await dbConn.query('ROLLBACK')
-      throw e
-    }
   }
 
   async utxosForInputsExists(inputs) {

--- a/src/interfaces/database.js
+++ b/src/interfaces/database.js
@@ -16,6 +16,7 @@ export interface Database<TxType> {
   storeBlocks(blocks: Array<Block>): Promise<void>;
   storeNewSnapshot(block: Block): Promise<void>;
   addNewTxToTransientSnapshots(txHash: string, txStatus: string): Promise<void>;
+  rollbackTo(blockHeight: number): Promise<void>;
   rollBackTransactions(blockHeight: number): Promise<void>;
   rollbackTransientSnapshots(blockHeight: number): Promise<void>;
   rollBackUtxoBackup(blockHeight: number): Promise<void>;

--- a/src/interfaces/database.js
+++ b/src/interfaces/database.js
@@ -15,6 +15,7 @@ export interface Database<TxType> {
   getTxStatus(txId: string): Promise<string>;
   storeBlocks(blocks: Array<Block>): Promise<void>;
   storeNewSnapshot(block: Block): Promise<void>;
+  addNewTxToTransientSnapshots(txHash: string, txStatus: string): Promise<void>;
   rollBackTransactions(blockHeight: number): Promise<void>;
   rollbackTransientSnapshots(blockHeight: number): Promise<void>;
   rollBackUtxoBackup(blockHeight: number): Promise<void>;
@@ -23,6 +24,8 @@ export interface Database<TxType> {
 
   storePoolOwnersInfo(inputs: Array<TxInputType>): Promise<boolean>;
   getLatestPoolOwnerHashes(): Promise<{}>;
+
+  doInTransaction(callback: Function): Promise<any>;
 }
 
 export interface DBConnection {


### PR DESCRIPTION
When we are accepting a tx to be proxied into the network we should not only store it as Pending or Failed, but also assign it to appropriate transient set linked to the current bestblock

P.S. Additionally in the same branch implemented the feature that dynamically selects the number of blocks to roll back at a fork detection. In the vast majority of case rolling back 1 or 2 blocks is enough to solve the problem.