### PR TITLE
Pending set tracking fix + TTL

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -25,6 +25,7 @@
   "gitHubRepo": "cardano-foundation/incentivized-testnet-stakepool-registry",
   "gitHubAuthUser": null,
   "gitHubAuthToken": null,
+  "pendingTxsTimeoutMinutes": 60,
   "rollbackBlocksCount": 25,
   "maxBlockBatchSize": 900,
   "defaultNetwork": "itn-rewards-v1",

--- a/src/entities/postgres-storage/database.js
+++ b/src/entities/postgres-storage/database.js
@@ -482,7 +482,11 @@ class DB<TxType: ByronTxType | ShelleyTxType> {
           return utxo
         })
       const isAllInputsFree = utxoInputs.length === 0 || (await this.utxosForInputsExists(utxoInputs))
-      this.logger.debug('[validateAndGroupPendingTxs] tx.time : ', tx.time, typeof tx.time)
+      try {
+        this.logger.debug('[validateAndGroupPendingTxs] tx.time : ', tx.time.getTime())
+      } catch (e) {
+        this.logger.debug('[validateAndGroupPendingTxs] failed to getTime() from tx.time : ', e)
+      }
       if (isAllInputsFree) {
         validTxs.push(tx.hash)
       } else {

--- a/src/entities/postgres-storage/database.js
+++ b/src/entities/postgres-storage/database.js
@@ -493,7 +493,7 @@ class DB<TxType: ByronTxType | ShelleyTxType> {
         })
       const isAllInputsFree = utxoInputs.length === 0 || (await this.utxosForInputsExists(utxoInputs))
       if (!isAllInputsFree) {
-        this.logger.info(`[DB.validateAndGroupPendingTxs] tx ${tx} inputs already spent`)
+        this.logger.info(`[DB.validateAndGroupPendingTxs] tx inputs already spent: `, tx)
         invalidTxs.push(tx.hash)
         continue
       }
@@ -501,7 +501,7 @@ class DB<TxType: ByronTxType | ShelleyTxType> {
         const lastUpdateTime = tx.last_update.getTime();
         const ageMillis = nowMillis - lastUpdateTime;
         if (ageMillis > this.pendingTxsTimeoutMillis) {
-          this.logger.info(`[DB.validateAndGroupPendingTxs] tx ${tx} has timed out`)
+          this.logger.info(`[DB.validateAndGroupPendingTxs] tx has timed out: `, tx)
           invalidTxs.push(tx.hash)
           continue
         }


### PR DESCRIPTION
1. Changed the pending set tracking query to NOT ignore currently pending txs if they were in the set at some point, but isn't currently.
2. Also implemented configurable Pending txs TTL at 1 hour by default.