### PR TITLE
Fix array usage in reward loader and extended logging

### DIFF
--- a/src/entities/schedulers/rewards-loader.js
+++ b/src/entities/schedulers/rewards-loader.js
@@ -24,10 +24,10 @@ const getEpochFromPath = (path: string): number => {
   const matchResult = epochFromPathRe.exec(path)
   if (matchResult !== null && matchResult !== undefined) {
     const { groups } = matchResult
-    const epoch = groups !== null && groups !== undefined ? groups.epoch : 0
+    const epoch = groups !== null && groups !== undefined ? groups.epoch : -1
     return parseInt(epoch, 10)
   }
-  return 0
+  return -1
 }
 
 class RewardsLoaderImpl extends BaseScheduler {
@@ -53,10 +53,10 @@ class RewardsLoaderImpl extends BaseScheduler {
 
   async run(): Promise<void> {
     this.logger.debug(`[${this.name}]: Subscribe for changes to ${this.jormunRewardsDirPath} dir.`)
-    const csvData = []
     chokidar.watch(this.jormunRewardsDirPath).on('all', (event, path) => {
       const epoch = getEpochFromPath(path)
-      if (epoch > 0) {
+      if (epoch >= 0) {
+        const csvData = []
         fs.createReadStream(path)
           .pipe(csv())
           .on('data', (data) => {
@@ -77,9 +77,7 @@ class RewardsLoaderImpl extends BaseScheduler {
           })
           .on('end', () => {
             this.logger.debug(`Update rewards data from ${path}`)
-            this.db.storeStakingRewards(csvData).then(() => {
-              csvData.length = 0
-            })
+            this.db.storeStakingRewards(csvData)
           })
       }
     })

--- a/src/entities/schedulers/rewards-loader.js
+++ b/src/entities/schedulers/rewards-loader.js
@@ -52,7 +52,8 @@ class RewardsLoaderImpl extends BaseScheduler {
 
 
   async run(): Promise<void> {
-    this.logger.debug(`[${this.name}]: Subscribe for changes to ${this.jormunRewardsDirPath} dir.`)
+    const logger = this.logger;
+    logger.debug(`[${this.name}]: Subscribe for changes to ${this.jormunRewardsDirPath} dir.`)
     chokidar.watch(this.jormunRewardsDirPath).on('all', (event, path) => {
       const epoch = getEpochFromPath(path)
       if (epoch >= 0) {
@@ -76,8 +77,11 @@ class RewardsLoaderImpl extends BaseScheduler {
             }
           })
           .on('end', () => {
-            this.logger.debug(`Update rewards data from ${path}`)
-            this.db.storeStakingRewards(csvData)
+            this.db.storeStakingRewards(csvData).then(res => {
+              logger.debug(`[${this.name}]: Updated rewards data from '${path}'`)
+            }, err => {
+              logger.error(`[${this.name}]: Failed to store rewards from '${path}'!`, err)
+            })
           })
       }
     })


### PR DESCRIPTION
1. Reworked how the same array instance can potentially be used in parallel running promises, which might cause it to be erased in a middle of beeing inserted into DB.
2. Extended the logging on DB insert success/fail a bit
3. Allowed rewards for epoch 0 to exist in theory