### PR TITLE
Rework reward loader on conflict

### DIFF
--- a/src/entities/schedulers/rewards-loader.js
+++ b/src/entities/schedulers/rewards-loader.js
@@ -53,7 +53,8 @@ class RewardsLoaderImpl extends BaseScheduler {
 
   async run(): Promise<void> {
     const logger = this.logger;
-    logger.debug(`[${this.name}]: Subscribe for changes to ${this.jormunRewardsDirPath} dir.`)
+    const loaderName = this.name;
+    logger.debug(`[${loaderName}]: Subscribe for changes to ${this.jormunRewardsDirPath} dir.`)
     chokidar.watch(this.jormunRewardsDirPath).on('all', (event, path) => {
       const epoch = getEpochFromPath(path)
       if (epoch >= 0) {
@@ -78,9 +79,9 @@ class RewardsLoaderImpl extends BaseScheduler {
           })
           .on('end', () => {
             this.db.storeStakingRewards(csvData).then(res => {
-              logger.debug(`[${this.name}]: Updated rewards data from '${path}'`)
+              logger.debug(`[${loaderName}]: Updated rewards data from '${path}'`)
             }, err => {
-              logger.error(`[${this.name}]: Failed to store rewards from '${path}'!`, err)
+              logger.error(`[${loaderName}]: Failed to store rewards from '${path}'!`, err)
             })
           })
       }


### PR DESCRIPTION
1. Changed the DB function a bit to have a NON-noop on-conflict resolving for rewards. We need this because Jormun at some point might export multiple files for the current latest epoch (forks) and then when they are edited we need to detect it and load the changed file.
2. Also a tiny change to remove an ambiguous `this` reference